### PR TITLE
fix: SVG rendering issue with filters attribute

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+libqtxdg (3.12.0-1deepin1) unstable; urgency=medium
+
+  * release 3.12.0-1deepin1
+  * Add Patch to fix #6480
+
+ -- Mike Chen <chenke@deepin.org>  Tue, 19 Dec 2023 13:49:08 +0800
+
 libqtxdg (3.12.0-1) unstable; urgency=medium
 
   * New upstream release.

--- a/debian/patches/Fix_6480_svg_with_filters.patch
+++ b/debian/patches/Fix_6480_svg_with_filters.patch
@@ -1,0 +1,48 @@
+diff --git a/src/xdgiconloader/xdgiconloader.cpp b/src/xdgiconloader/xdgiconloader.cpp
+index 217eca1..95aecc8 100644
+--- a/src/xdgiconloader/xdgiconloader.cpp
++++ b/src/xdgiconloader/xdgiconloader.cpp
+@@ -53,7 +53,7 @@
+ #include <QImageReader>
+ #include <QXmlStreamReader>
+ #include <QFileSystemWatcher>
+-#include <QSvgRenderer>
++#include <QBuffer>
+ 
+ #include <private/qhexstring_p.h>
+ 
+@@ -829,12 +829,12 @@ QPixmap ScalableEntry::pixmap(const QSize &size, QIcon::Mode mode, QIcon::State
+         pm = QPixmap(icnSize, icnSize);
+         pm.fill(Qt::transparent);
+ 
+-        QSvgRenderer renderer;
+-        if (renderer.load(filename))
+-        {
++        QImageReader imageReader(filename);
++        if (imageReader.canRead()) {
++            imageReader.setScaledSize(QSize(icnSize, icnSize));
+             QPainter p;
+             p.begin(&pm);
+-            renderer.render(&p, QRect(0, 0, icnSize, icnSize));
++            p.drawImage(0, 0, imageReader.read());
+             p.end();
+         }
+ 
+@@ -928,11 +928,14 @@ QPixmap ScalableFollowsColorEntry::pixmap(const QSize &size, QIcon::Mode mode, Q
+ 
+             if (!svgBuffer.isEmpty())
+             {
+-                QSvgRenderer renderer;
+-                renderer.load(svgBuffer);
++                QBuffer buffer;
++                buffer.setData(svgBuffer);
++                buffer.open(QIODevice::ReadOnly);
++                QImageReader imageReader(&buffer);
++                imageReader.setScaledSize(QSize(icnSize, icnSize));
+                 QPainter p;
+                 p.begin(&pm);
+-                renderer.render(&p, QRect(0, 0, icnSize, icnSize));
++                p.drawImage(0, 0, imageReader.read());
+                 p.end();
+             }
+         }

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -1,0 +1,1 @@
+Fix_6480_svg_with_filters.patch


### PR DESCRIPTION
From: https://github.com/lxqt/libqtxdg/pull/247
Use QImageReader instead of QSvgRender for XdgIconLoader QSvgRender itself only support SVG 1.2 Tiny for rendering so SVGs that more complex might not able to rendered properly. Thus, some DE like KDE and DDE provides their own Qt icon engine and registered them as for SVG icons, and seems that causes libqtxdg have issues, so lxqt/libqtxdg/pull/246 was there.

But user or DE might still want to install or provide Qt image formats plugins for better SVG files/icons rendering, using QSvgRender will stop the Qt image formats plugin from being used.

Using QImageReader will still allow us avoiding the usage of Qt icon engines, but kepts the ability to make Qt image formats plugin to work properly.

This patch originally provided by @zccrs

Issue: https://github.com/linuxdeepin/developer-center/issues/6480